### PR TITLE
Bump supported slurm version to 0x0e0b04 (14.11.4)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ logging.basicConfig(level=20)
 #VERSION = imp.load_source("/tmp", "pyslurm/__init__.py").__version__
 __version__ = "14.11.0-0"
 __min_slurm_hex_version__ = "0x0e0b00"
-__max_slurm_hex_version__ = "0x0e0b02"
+__max_slurm_hex_version__ = "0x0e0b04"
 
 def fatal(logstring, code=1):
 	logger.error("Fatal: " + logstring)


### PR DESCRIPTION
Fixes #42

The Slurm API hasn't changed, so the existing code already
supports the latest Slurm release, 14.11.4.