### PR TITLE
Remove faulty semi-colon + backport to cython 0.15

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ The current branch is based on the Slurm 14.11.0 to 14.11.4 API
 Prerequistes
 =============
 
-This version has been tested with Slurm 14.11.0-14.11.4, Cython 0.21.1 and Python 2.7.4
+This version has been tested with Slurm 14.11.0-14.11.4, Cython 0.15.1 and Python 2.6.6
 
 * [Slurm] http://www.schedmd.com
 * [Python] http://www.python.org

--- a/pyslurm/slurm.pxd
+++ b/pyslurm/slurm.pxd
@@ -574,7 +574,7 @@ cdef extern from 'slurm/slurm.h' nogil:
 		char *mloaderimage
 		char *ramdiskimage
 		uint32_t req_switch
-		dynamic_plugin_data_t *select_jobinfo;
+		dynamic_plugin_data_t *select_jobinfo
 		char *std_err
 		char *std_in
 		char *std_out
@@ -1235,7 +1235,7 @@ cdef extern from 'slurm/slurm.h' nogil:
 		uint32_t available
 		uint8_t remote
 
-	ctypedef slurm_license_info slurm_license_info_t;
+	ctypedef slurm_license_info slurm_license_info_t
 
 	ctypedef struct license_info_msg:
 		time_t last_update

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ if sys.version_info[:2] < (2, 6):
 
 compiler_dir = os.path.join(get_python_lib(prefix=''), 'src/pyslurm/')
 
-CyVersion_min = "0.21"
+CyVersion_min = "0.15"
 try:
 	from Cython.Distutils import build_ext
 	from Cython.Compiler.Version import version as CyVersion


### PR DESCRIPTION
Only these wrong semi-colons prevent PySLURM from compiling with
Cython 0.15. So remove them and set cython version check back to 0.15.

After applying this patch, build on a system with Debian Squeeze with Cython 0.15.1 and Slurm 14.11.4:
```
# python setup.py build
INFO:root:Info:
INFO:root:Info: Building PySlurm (14.11.0-0)
INFO:root:Info: ------------------------------
INFO:root:Info:
INFO:root:Info: Cython version 0.15.1 installed

INFO:root:Info: Clean - checking for objects to clean
INFO:root:Info: Clean - completed
INFO:root:Info: Build - Detected Slurm include file version - 0x0e0b04 (14.11.4)
INFO:root:Info: Build - Generating pyslurm/bluegene.pxi file
running build
running build_py
creating build
creating build/lib.linux-x86_64-2.6
creating build/lib.linux-x86_64-2.6/pyslurm
copying pyslurm/__init__.py -> build/lib.linux-x86_64-2.6/pyslurm
running build_ext
cythoning pyslurm/pyslurm.pyx to pyslurm/pyslurm.c
building 'pyslurm.pyslurm' extension
creating build/temp.linux-x86_64-2.6
creating build/temp.linux-x86_64-2.6/pyslurm
gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -I/usr/include -I. -I/usr/include/python2.6 -c pyslurm/pyslurm.c -o build/temp.linux-x86_64-2.6/pyslurm/pyslu                                  rm.o
gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions build/temp.linux-x86_64-2.6/pyslurm/pyslurm.o -L/usr/lib/slurm -Wl,-R/usr/lib/ -Wl,-R/usr/lib/slurm -lslurmdb -o build/lib.linux-x86_64-2.6/pyslu                                  rm/pyslurm.so
```

Install:

```
# python setup.py install
INFO:root:Info:
INFO:root:Info: Building PySlurm (14.11.0-0)
INFO:root:Info: ------------------------------
INFO:root:Info:
INFO:root:Info: Cython version 0.15.1 installed

running install
running build
running build_py
running build_ext
skipping 'pyslurm/pyslurm.c' Cython extension (up-to-date)
running install_lib
creating /usr/local/lib/python2.6/dist-packages/pyslurm
copying build/lib.linux-x86_64-2.6/pyslurm/pyslurm.so -> /usr/local/lib/python2.6/dist-packages/pyslurm
copying build/lib.linux-x86_64-2.6/pyslurm/__init__.py -> /usr/local/lib/python2.6/dist-packages/pyslurm
byte-compiling /usr/local/lib/python2.6/dist-packages/pyslurm/__init__.py to __init__.pyc
running install_egg_info
Writing /usr/local/lib/python2.6/dist-packages/pyslurm-14.11.0_0.egg-info
```

Usage:

```
# python
Python 2.6.6 (r266:84292, Aug 12 2014, 07:57:07)
[GCC 4.4.5] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import pyslurm
>>> pyslurm.job().get()
{}
>>> pyslurm.node().get()
[huge dict]
```

Thanks for considering and merging!