### PR TITLE
Slurm 14.11.5 Python3 Compatibility

### DIFF
--- a/pyslurm/pyslurm.pyx
+++ b/pyslurm/pyslurm.pyx
@@ -648,7 +648,7 @@ cdef class partition:
 
 		return self._PartDict.get(partID, {})
 
-	def find(self, char *name='', val=''):
+	def find(self, name='', val=''):
 
 		u"""Search for a property and associated value in the retrieved partition data.
 
@@ -1720,7 +1720,7 @@ cdef class job:
 
 		return self._JobDict.get(jobID, {})
 
-	def find(self, char *name='', val=''):
+	def find(self, name='', val=''):
 
 		u"""Search for a property and associated value in the retrieved job data.
 
@@ -3121,7 +3121,7 @@ cdef class reservation:
 
 		return self._ResDict.get(resID, {})
 
-	def find(self, char *name='', val=''):
+	def find(self, name='', val=''):
 
 		u"""Search for a property and associated value in the retrieved reservation data
 
@@ -3505,7 +3505,7 @@ cdef class block:
 
 		return self._BlockDict.get(blockID, {})
 
-	def find(self, char *name='', val=''):
+	def find(self, name='', val=''):
 
 		u"""Search for a property and associated value in the retrieved block data.
 

--- a/setup.py
+++ b/setup.py
@@ -244,7 +244,7 @@ if args[1] == 'build' or args[1] == 'build_ext':
 
 	# Test for supported min and max Slurm versions 
 
-        SLURM_INC_VER = read_inc_version("%s/slurm/slurm.h" % SLURM_INC)
+	SLURM_INC_VER = read_inc_version("%s/slurm/slurm.h" % SLURM_INC)
 	if (int(SLURM_INC_VER,16) < int(__min_slurm_hex_version__,16)) or (int(SLURM_INC_VER,16) > int(__max_slurm_hex_version__,16)):
 		fatal("Build - Incorrect slurm version detected, require Slurm-%s to slurm-%s" % (inc_vers2str(__min_slurm_hex_version__), inc_vers2str(__max_slurm_hex_version__)))
 		sys.exit(-1)


### PR DESCRIPTION
For me, pyslurm works on both python 2.7.5 and python 3.3/3.4 as is, with the exception of the find() commands, which fail. For example pyslurm.job().find('user_id', 5000) fails with the following error:

    In [31]: a.find('user_id', 20043)
    ---------------------------------------------------------------------------
    TypeError                                 Traceback (most recent call last)
    <ipython-input-31-a99217e1171e> in <module>()
    ----> 1 a.find('user_id', 20043)

    pyslurm/pyslurm.pyx in pyslurm.pyslurm.job.find (pyslurm/pyslurm.c:23408)()

    TypeError: expected bytes, str found
    
By changing the function definition from ``find(self, char *name='', val='')`` to ``find(self, name='', val='')`` it is possible to eliminate this error in python3 without affecting performance in python2. I have tested this fix extensively in both python 2.7.5 and python 3.3.4. Furthermore, there is no reason to expect that the C character definiton should be needed in these functions, python's string handlind should actually be more efficient in these cases.

Additionally, compilation failed for me due to the use of spaces on one line of setup.py. I fixed this by switching it to a tab character in a seperate commit.