### PR TITLE
Added compatibility for SLURM 15.08.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ This release has been tested with :
 
 	* Slurm 15.08.0-0rc1, Cython 0.22.1 and Python 2.7.4
 	* Slurm 15.08.0-0rc1, Cython 0.23.1 and Python 2.7.4
+	* Slurm 15.08.1, Cython 0.23.4 and Python 2.7.5
 
 Installation
 ************

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ logging.basicConfig(level=20)
 #VERSION = imp.load_source("/tmp", "pyslurm/__init__.py").__version__
 __version__ = "15.08.0"
 __min_slurm_hex_version__ = "0x0f0800"
-__max_slurm_hex_version__ = "0x0f0800"
+__max_slurm_hex_version__ = "0x0f0801"
 
 def fatal(logstring, code=1):
 	logger.error("Fatal: " + logstring)


### PR DESCRIPTION
I'm currently using the [OpenHPC](http://openhpc.community/wp-content/uploads/Install_guide-CentOS7.1-1.0.pdf) RPMs, which currently uses SLURM 15.08.1.

Neither of the two current pyslurm 15.08.X branches allow for SLURM version 15.08.1 without modifying setup.py.