### PR TITLE
Fixed docstring so that pydoc renders the description

### DIFF
--- a/pyslurm/__init__.py
+++ b/pyslurm/__init__.py
@@ -1,8 +1,8 @@
-
-#
-# Absolute Import introduced in Python2.5 ?
-#
-
+"""
+PySLURM is a Python/Cython extension module to the Simple Linux Unified
+Resource Manager (SLURM) API. SLURM is typically used on HPC clusters such as
+those listed on the TOP500 but can also be used on clusters of any size.
+"""
 from __future__ import absolute_import
 
 import os


### PR DESCRIPTION
`pydoc` currently renders as follows:

```
Help on package pyslurm:

NAME
    pyslurm

FILE
    /usr/lib64/python2.7/site-packages/pyslurm/__init__.py

DESCRIPTION
    #  Absolute Import introduced in Python2.5 ?

PACKAGE CONTENTS
    pyslurm
...
```